### PR TITLE
feat: configurable partition fn for sink

### DIFF
--- a/src/bytewax_s2/__init__.py
+++ b/src/bytewax_s2/__init__.py
@@ -4,10 +4,11 @@ __all__ = [
     "S2Sink",
     "S2SourceRecord",
     "S2SinkRecord",
+    "S2SinkPartitionFn",
 ]
 
 from bytewax_s2._io import (
     S2Sink,
     S2Source,
 )
-from bytewax_s2._types import S2Config, S2SinkRecord, S2SourceRecord
+from bytewax_s2._types import S2Config, S2SinkPartitionFn, S2SinkRecord, S2SourceRecord

--- a/src/bytewax_s2/_io.py
+++ b/src/bytewax_s2/_io.py
@@ -223,7 +223,12 @@ class S2Sink(FixedPartitionedSink):
     def part_fn(self, item_key: str) -> int:
         match self._partition_fn:
             case S2SinkPartitionFn.DIRECT:
-                return self._partition_idx_map[item_key]
+                if item_key in self._partitions:
+                    return self._partition_idx_map[item_key]
+                else:
+                    raise RuntimeError(
+                        f"item with key: {item_key} doesn't match any of the existing partitions: {self._partitions}"
+                    )
             case S2SinkPartitionFn.HASHED:
                 return super().part_fn(item_key)
             case _:

--- a/src/bytewax_s2/_types.py
+++ b/src/bytewax_s2/_types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Enum
 
 
 @dataclass(slots=True, frozen=True)
@@ -50,3 +51,8 @@ class S2SinkRecord:
 
     body: bytes
     headers: list[tuple[bytes, bytes]] = field(default_factory=list)
+
+
+class S2SinkPartitionFn(Enum):
+    HASHED = 1
+    DIRECT = 2


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds configurable partition function to `S2Sink` and URL encoding for stream names in `S2` methods.
> 
>   - **Behavior**:
>     - `S2Sink` in `_io.py` now supports configurable partitioning via `partition_fn` parameter, defaulting to `S2SinkPartitionFn.HASHED`.
>     - Adds `part_fn()` in `S2Sink` to handle partitioning logic based on `partition_fn`.
>     - URL encoding for stream names in `S2` methods (`check_head`, `check_tail`, `append`, `read`) using `_quoted()` function.
>   - **Types**:
>     - Introduces `S2SinkPartitionFn` enum in `_types.py` with `HASHED` and `DIRECT` options.
>   - **Misc**:
>     - Updates `__init__.py` to include `S2SinkPartitionFn` in exports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fbytewax-s2&utm_source=github&utm_medium=referral)<sup> for af74af50945f993bc09b2cae9bd65d1d889b9900. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->