### PR TITLE
chore: add example dataflows for bluesky offsite mentions

### DIFF
--- a/examples/sink.py
+++ b/examples/sink.py
@@ -1,0 +1,121 @@
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import bytewax.operators as op
+import websockets
+from bytewax.dataflow import Dataflow
+from bytewax.inputs import FixedPartitionedSource, StatefulSourcePartition, batch_async
+
+from bytewax_s2 import S2Config, S2Sink, S2SinkPartitionFn, S2SinkRecord
+
+AUTH_TOKEN = os.environ["S2_AUTH_TOKEN"]
+BASIN = os.environ["S2_BASIN"]
+OFFSITE_TO_STREAM = {
+    "amazon.com": "ecommerce/amazon",
+    "ebay.com": "ecommerce/ebay",
+    "etsy.com": "ecommerce/etsy",
+    "facebook.com": "social/facebook",
+    "reddit.com": "social/reddit",
+    "youtube.com": "social/youtube",
+    "bbc.com": "news/bbc",
+    "cbc.ca": "news/cbc",
+    "cnn.com": "news/cnn",
+}
+
+
+async def wss_agen(uri: str):
+    async with websockets.connect(uri) as websocket:
+        while True:
+            event = await websocket.recv()
+            yield json.loads(event)
+
+
+class JetstreamSourcePartition(StatefulSourcePartition):
+    def __init__(self, uri: str):
+        self.batcher = batch_async(wss_agen(uri), timedelta(seconds=0.5), 1000)
+
+    def next_batch(self):
+        return next(self.batcher)
+
+    def snapshot(self):
+        pass
+
+
+class JetstreamSource(FixedPartitionedSource):
+    def __init__(self, wss_uri: str):
+        self.uri = wss_uri
+
+    def list_parts(self):
+        return [self.uri]
+
+    def build_part(self, _step_id, for_part, _resume_state):
+        return JetstreamSourcePartition(uri=for_part)
+
+
+def is_english_post(event: dict) -> bool:
+    if (
+        event.get("kind") == "commit"
+        and event.get("commit", {}).get("operation") == "create"
+        and event.get("commit", {}).get("collection") == "app.bsky.feed.post"
+    ):
+        langs = event.get("commit", {}).get("record", {}).get("langs", [])
+        if "en" in langs:
+            return True
+    return False
+
+
+def offsite_source(record: dict) -> tuple[str, str] | tuple[None, None]:
+    for facet in record.get("facets", []):
+        for feature in facet.get("features", []):
+            offsite_uri = feature.get("uri")
+            if offsite_uri:
+                for offsite in OFFSITE_TO_STREAM:
+                    if offsite in offsite_uri:
+                        return (offsite, offsite_uri)
+    return (None, None)
+
+
+def offsite_english_posts(event: dict) -> tuple[str, S2SinkRecord] | None:
+    if is_english_post(event):
+        (offsite, offsite_uri) = offsite_source(
+            event.get("commit", {}).get("record", {})
+        )
+        if offsite is not None:
+            data = {
+                "did": event.get("did"),
+                "rkey": event.get("commit", {}).get("rkey"),
+                "created_at": event.get("commit", {})
+                .get("record", {})
+                .get("createdAt"),
+                "observed_at": datetime.now(timezone.utc).isoformat(),
+                "cid": event.get("commit", {}).get("cid"),
+                "offsite": offsite,
+                "offsite_uri": offsite_uri,
+            }
+            return (
+                OFFSITE_TO_STREAM[offsite],
+                S2SinkRecord(body=json.dumps(data).encode()),
+            )
+    return None
+
+
+flow = Dataflow("s2_sink_example")
+bsky_events = op.input(
+    "bluesky_source",
+    flow,
+    JetstreamSource(wss_uri="wss://jetstream2.us-west.bsky.network/subscribe"),
+)
+offsite_en_posts = op.filter_map(
+    "filter_offsite_english_posts", bsky_events, offsite_english_posts
+)
+op.output(
+    "s2_sink",
+    offsite_en_posts,
+    S2Sink(
+        config=S2Config(auth_token=AUTH_TOKEN),
+        basin=BASIN,
+        stream_prefix="",
+        partition_fn=S2SinkPartitionFn.DIRECT,
+    ),
+)

--- a/examples/source.py
+++ b/examples/source.py
@@ -135,12 +135,13 @@ chart = TerminalBarChartSink(
 )
 
 
-def handler(_signum, _frame):
+def graceful_exit(_signum, _frame):
     chart.close()
     sys.exit(0)
 
 
-signal.signal(signal.SIGTSTP, handler)
+signal.signal(signal.SIGTSTP, graceful_exit)
+signal.signal(signal.SIGTERM, graceful_exit)
 
 try:
     flow = Dataflow("s2_source_example")

--- a/examples/source.py
+++ b/examples/source.py
@@ -1,0 +1,173 @@
+import json
+import os
+import signal
+import sys
+from datetime import datetime, timedelta, timezone
+
+import bytewax.operators as op
+import plotext as plt  # type: ignore
+from bytewax.dataflow import Dataflow
+from bytewax.operators.windowing import (
+    EventClock,
+    TumblingWindower,
+    count_window,
+)
+from bytewax.outputs import DynamicSink, StatelessSinkPartition
+from rich.ansi import AnsiDecoder
+from rich.console import Group
+from rich.jupyter import JupyterMixin
+from rich.layout import Layout
+from rich.live import Live
+from rich.panel import Panel
+
+from bytewax_s2 import S2Config, S2Source
+
+AUTH_TOKEN = os.environ["S2_AUTH_TOKEN"]
+BASIN = os.environ["S2_BASIN"]
+OFFSITE_KIND = os.environ["OFFSITE_KIND"]
+OFFSITES_BY_KIND = {
+    "ecommerce": ["amazon.com", "ebay.com", "etsy.com"],
+    "social": ["facebook.com", "reddit.com", "youtube.com"],
+    "news": ["bbc.com", "cbc.ca", "cnn.com"],
+}
+if OFFSITE_KIND not in OFFSITES_BY_KIND:
+    raise ValueError("OFFSITE_KIND is invalid")
+
+
+class PlotextMixin(JupyterMixin):
+    def __init__(self, labels: list[str], values: list):
+        self.decoder = AnsiDecoder()
+        self.labels = labels
+        self.values = values
+
+    def __rich_console__(self, _console, _options):
+        plt.simple_bar(self.labels, self.values, width=100)
+        canvas = plt.build()
+        self.rich_canvas = Group(*self.decoder.decode(canvas))
+        yield self.rich_canvas
+
+
+def panel(metrics: dict, labels: list[str], title: str) -> Panel:
+    return Panel(
+        PlotextMixin(labels, [metrics[label] for label in labels]),
+        title=title,
+    )
+
+
+class StreamingBarChart(StatelessSinkPartition):
+    def __init__(self, labels: list[str], title_prefix: str):
+        self.last_window_id = None
+        self.labels = labels
+        self.recent_title = f"{title_prefix} (recent)"
+        self.cumu_title = f"{title_prefix} (cumulative)"
+        self.recent = {label: 0 for label in labels}
+        self.cumu = {label: 0 for label in labels}
+        self.layout = Layout(name="root")
+        self.layout.split_column(
+            Layout(name="recent"),
+            Layout(name="cumu"),
+        )
+        self.layout["recent"].update(panel(self.recent, self.labels, self.recent_title))
+        self.layout["cumu"].update(panel(self.cumu, self.labels, self.cumu_title))
+        self.live = Live(self.layout, auto_refresh=False)
+        self.live.start(refresh=True)
+
+    def write_batch(self, items: list[dict]):
+        for item in items:
+            window_id = item["window_id"]
+            if window_id < 0:
+                continue
+            if self.last_window_id is None:
+                self.last_window_id = window_id
+            if window_id > self.last_window_id:
+                self.layout["recent"].update(
+                    panel(self.recent, self.labels, self.recent_title)
+                )
+                self.layout["cumu"].update(
+                    panel(self.cumu, self.labels, self.cumu_title)
+                )
+                self.live.refresh()
+                self.last_window_id = window_id
+                self.recent = {label: 0 for label in self.labels}
+            self.recent[item["label"]] += item["value"]
+            self.cumu[item["label"]] += item["value"]
+
+    def close(self):
+        self.live.stop()
+
+
+class TerminalBarChartSink(DynamicSink):
+    def __init__(self, labels: list[str], title_prefix: str):
+        self.labels = labels
+        self.title_prefix = title_prefix
+
+    def build(self, _step_id, _worker_index, worker_count) -> StreamingBarChart:
+        if worker_count != 1:
+            raise ValueError(
+                "TerminalBarChartSink must not be used with more than one worker"
+            )
+        self.chart = StreamingBarChart(
+            labels=self.labels, title_prefix=self.title_prefix
+        )
+        return self.chart
+
+    def close(self):
+        self.chart.close()
+
+
+def extract_timestamp(event: dict) -> datetime:
+    return datetime.fromisoformat(event["observed_at"])
+
+
+clock = EventClock(
+    ts_getter=extract_timestamp,
+    wait_for_system_duration=timedelta(seconds=0),
+)
+
+windower = TumblingWindower(
+    length=timedelta(seconds=10),
+    align_to=datetime.now(timezone.utc),
+)
+
+
+chart = TerminalBarChartSink(
+    labels=OFFSITES_BY_KIND[OFFSITE_KIND], title_prefix="Offsite mentions in Bluesky"
+)
+
+
+def handler(_signum, _frame):
+    chart.close()
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTSTP, handler)
+
+try:
+    flow = Dataflow("s2_source_example")
+    offsite_posts_raw = op.input(
+        "s2_source",
+        flow,
+        S2Source(
+            config=S2Config(auth_token=AUTH_TOKEN),
+            basin=BASIN,
+            stream_prefix=OFFSITE_KIND,
+        ),
+    )
+    offsite_posts = op.map(
+        "parse_offsite_posts", offsite_posts_raw, lambda sr: json.loads(sr.body)
+    )
+    windowed_offsite_mentions = count_window(
+        "count_offsite_mentions",
+        offsite_posts,
+        clock,
+        windower,
+        lambda event: event["offsite"],
+    )
+    formatted_offsite_mentions = op.map(
+        "format_offsite_mentions",
+        windowed_offsite_mentions.down,
+        lambda x: {"window_id": x[1][0], "label": x[0], "value": x[1][1]},
+    )
+    op.output("chart_sink", formatted_offsite_mentions, chart)
+except KeyboardInterrupt:
+    chart.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-dev = ["mypy>=1.15.0", "ruff>=0.9.6"]
+dev = [
+    "mypy>=1.15.0",
+    "plotext>=5.3.2",
+    "rich>=13.9.4",
+    "ruff>=0.9.6",
+    "websockets>=15.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,10 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "plotext" },
+    { name = "rich" },
     { name = "ruff" },
+    { name = "websockets" },
 ]
 
 [package.metadata]
@@ -52,7 +55,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "plotext", specifier = ">=5.3.2" },
+    { name = "rich", specifier = ">=13.9.4" },
     { name = "ruff", specifier = ">=0.9.6" },
+    { name = "websockets", specifier = ">=15.0" },
 ]
 
 [[package]]
@@ -122,6 +128,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
 name = "mypy"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -162,12 +189,30 @@ wheels = [
 ]
 
 [[package]]
+name = "plotext"
+version = "5.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/d7/f75f397af966fe252d0d34ffd3cae765317fce2134f925f95e7d6725d1ce/plotext-5.3.2.tar.gz", hash = "sha256:52d1e932e67c177bf357a3f0fe6ce14d1a96f7f7d5679d7b455b929df517068e", size = 61967 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/1e/12fe7c40cd2099a1f454518754ed229b01beaf3bbb343127f0cc13ce6c22/plotext-5.3.2-py3-none-any.whl", hash = "sha256:394362349c1ddbf319548cfac17ca65e6d5dfc03200c40dfdc0503b3e95a2283", size = 64047 },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/62/14/7d0f567991f3a9af8d1cd4f619040c93b68f09a02b6d0b6ab1b2d1ded5fe/prometheus_client-0.21.1.tar.gz", hash = "sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb", size = 78551 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/c2/ab7d37426c179ceb9aeb109a85cda8948bb269b7561a0be870cc656eefe4/prometheus_client-0.21.1-py3-none-any.whl", hash = "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301", size = 54682 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
@@ -183,6 +228,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
 ]
 
 [[package]]
@@ -247,4 +305,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/7a/8bc4d15af7ff30f7ba34f9a172063bfcee9f5001d7cef04bee800a658f33/websockets-15.0.tar.gz", hash = "sha256:ca36151289a15b39d8d683fd8b7abbe26fc50be311066c5f8dcf3cb8cee107ab", size = 175574 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/16/81a7403c8c0a33383de647e89c07824ea6a654e3877d6ff402cbae298cb8/websockets-15.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dd24c4d256558429aeeb8d6c24ebad4e982ac52c50bc3670ae8646c181263965", size = 174702 },
+    { url = "https://files.pythonhosted.org/packages/ef/40/4629202386a3bf1195db9fe41baeb1d6dfd8d72e651d9592d81dae7fdc7c/websockets-15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f83eca8cbfd168e424dfa3b3b5c955d6c281e8fc09feb9d870886ff8d03683c7", size = 172359 },
+    { url = "https://files.pythonhosted.org/packages/7b/33/dfb650e822bc7912d8c542c452497867af91dec81e7b5bf96aca5b419d58/websockets-15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4095a1f2093002c2208becf6f9a178b336b7572512ee0a1179731acb7788e8ad", size = 172604 },
+    { url = "https://files.pythonhosted.org/packages/2e/52/666743114513fcffd43ee5df261a1eb5d41f8e9861b7a190b730732c19ba/websockets-15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb915101dfbf318486364ce85662bb7b020840f68138014972c08331458d41f3", size = 182145 },
+    { url = "https://files.pythonhosted.org/packages/9c/63/5273f146b13aa4a057a95ab0855d9990f3a1ced63693f4365135d1abfacc/websockets-15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:45d464622314973d78f364689d5dbb9144e559f93dca11b11af3f2480b5034e1", size = 181152 },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/075697f3f97de7c26b73ae96d952e13fa36393e0db3f028540b28954e0a9/websockets-15.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ace960769d60037ca9625b4c578a6f28a14301bd2a1ff13bb00e824ac9f73e55", size = 181523 },
+    { url = "https://files.pythonhosted.org/packages/25/87/06d091bbcbe01903bed3dad3bb4a1a3c516f61e611ec31fffb28abe4974b/websockets-15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7cd4b1015d2f60dfe539ee6c95bc968d5d5fad92ab01bb5501a77393da4f596", size = 181791 },
+    { url = "https://files.pythonhosted.org/packages/77/08/5063b6cc1b2aa1fba2ee3b578b777db22fde7145f121d07fd878811e983b/websockets-15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4f7290295794b5dec470867c7baa4a14182b9732603fd0caf2a5bf1dc3ccabf3", size = 181231 },
+    { url = "https://files.pythonhosted.org/packages/86/ff/af23084df0a7405bb2add12add8c17d6192a8de9480f1b90d12352ba2b7d/websockets-15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3abd670ca7ce230d5a624fd3d55e055215d8d9b723adee0a348352f5d8d12ff4", size = 181191 },
+    { url = "https://files.pythonhosted.org/packages/21/ce/b2bdfcf49201dee0b899edc6a814755763ec03d74f2714923d38453a9e8d/websockets-15.0-cp311-cp311-win32.whl", hash = "sha256:110a847085246ab8d4d119632145224d6b49e406c64f1bbeed45c6f05097b680", size = 175666 },
+    { url = "https://files.pythonhosted.org/packages/8d/7b/444edcd5365538c226b631897975a65bbf5ccf27c77102e17d8f12a306ea/websockets-15.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7bbbe2cd6ed80aceef2a14e9f1c1b61683194c216472ed5ff33b700e784e37", size = 176105 },
+    { url = "https://files.pythonhosted.org/packages/22/1e/92c4547d7b2a93f848aedaf37e9054111bc00dc11bff4385ca3f80dbb412/websockets-15.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cccc18077acd34c8072578394ec79563664b1c205f7a86a62e94fafc7b59001f", size = 174709 },
+    { url = "https://files.pythonhosted.org/packages/9f/37/eae4830a28061ba552516d84478686b637cd9e57d6a90b45ad69e89cb0af/websockets-15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4c22992e24f12de340ca5f824121a5b3e1a37ad4360b4e1aaf15e9d1c42582d", size = 172372 },
+    { url = "https://files.pythonhosted.org/packages/46/2f/b409f8b8aa9328d5a47f7a301a43319d540d70cf036d1e6443675978a988/websockets-15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1206432cc6c644f6fc03374b264c5ff805d980311563202ed7fef91a38906276", size = 172607 },
+    { url = "https://files.pythonhosted.org/packages/d6/81/d7e2e4542d4b4df849b0110df1b1f94f2647b71ab4b65d672090931ad2bb/websockets-15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d3cc75ef3e17490042c47e0523aee1bcc4eacd2482796107fd59dd1100a44bc", size = 182422 },
+    { url = "https://files.pythonhosted.org/packages/b6/91/3b303160938d123eea97f58be363f7dbec76e8c59d587e07b5bc257dd584/websockets-15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b89504227a5311610e4be16071465885a0a3d6b0e82e305ef46d9b064ce5fb72", size = 181362 },
+    { url = "https://files.pythonhosted.org/packages/f2/8b/df6807f1ca339c567aba9a7ab03bfdb9a833f625e8d2b4fc7529e4c701de/websockets-15.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56e3efe356416bc67a8e093607315951d76910f03d2b3ad49c4ade9207bf710d", size = 181787 },
+    { url = "https://files.pythonhosted.org/packages/21/37/e6d3d5ebb0ebcaf98ae84904205c9dcaf3e0fe93e65000b9f08631ed7309/websockets-15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f2205cdb444a42a7919690238fb5979a05439b9dbb73dd47c863d39640d85ab", size = 182058 },
+    { url = "https://files.pythonhosted.org/packages/c9/df/6aca296f2be4c638ad20908bb3d7c94ce7afc8d9b4b2b0780d1fc59b359c/websockets-15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:aea01f40995fa0945c020228ab919b8dfc93fc8a9f2d3d705ab5b793f32d9e99", size = 181434 },
+    { url = "https://files.pythonhosted.org/packages/88/f1/75717a982bab39bbe63c83f9df0e7753e5c98bab907eb4fb5d97fe5c8c11/websockets-15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a9f8e33747b1332db11cf7fcf4a9512bef9748cb5eb4d3f7fbc8c30d75dc6ffc", size = 181431 },
+    { url = "https://files.pythonhosted.org/packages/e7/15/cee9e63ed9ac5bfc1a3ae8fc6c02c41745023c21eed622eef142d8fdd749/websockets-15.0-cp312-cp312-win32.whl", hash = "sha256:32e02a2d83f4954aa8c17e03fe8ec6962432c39aca4be7e8ee346b05a3476904", size = 175678 },
+    { url = "https://files.pythonhosted.org/packages/4e/00/993974c60f40faabb725d4dbae8b072ef73b4c4454bd261d3b1d34ace41f/websockets-15.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc02b159b65c05f2ed9ec176b715b66918a674bd4daed48a9a7a590dd4be1aa", size = 176119 },
+    { url = "https://files.pythonhosted.org/packages/12/23/be28dc1023707ac51768f848d28a946443041a348ee3a54abdf9f6283372/websockets-15.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d2244d8ab24374bed366f9ff206e2619345f9cd7fe79aad5225f53faac28b6b1", size = 174714 },
+    { url = "https://files.pythonhosted.org/packages/8f/ff/02b5e9fbb078e7666bf3d25c18c69b499747a12f3e7f2776063ef3fb7061/websockets-15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3a302241fbe825a3e4fe07666a2ab513edfdc6d43ce24b79691b45115273b5e7", size = 172374 },
+    { url = "https://files.pythonhosted.org/packages/8e/61/901c8d4698e0477eff4c3c664d53f898b601fa83af4ce81946650ec2a4cb/websockets-15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:10552fed076757a70ba2c18edcbc601c7637b30cdfe8c24b65171e824c7d6081", size = 172605 },
+    { url = "https://files.pythonhosted.org/packages/d2/4b/dc47601a80dff317aecf8da7b4ab278d11d3494b2c373b493e4887561f90/websockets-15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c53f97032b87a406044a1c33d1e9290cc38b117a8062e8a8b285175d7e2f99c9", size = 182380 },
+    { url = "https://files.pythonhosted.org/packages/83/f7/b155d2b38f05ed47a0b8de1c9ea245fcd7fc625d89f35a37eccba34b42de/websockets-15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1caf951110ca757b8ad9c4974f5cac7b8413004d2f29707e4d03a65d54cedf2b", size = 181325 },
+    { url = "https://files.pythonhosted.org/packages/d3/ff/040a20c01c294695cac0e361caf86f33347acc38f164f6d2be1d3e007d9f/websockets-15.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bf1ab71f9f23b0a1d52ec1682a3907e0c208c12fef9c3e99d2b80166b17905f", size = 181763 },
+    { url = "https://files.pythonhosted.org/packages/cb/6a/af23e93678fda8341ac8775e85123425e45c608389d3514863c702896ea5/websockets-15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bfcd3acc1a81f106abac6afd42327d2cf1e77ec905ae11dc1d9142a006a496b6", size = 182097 },
+    { url = "https://files.pythonhosted.org/packages/7e/3e/1069e159c30129dc03c01513b5830237e576f47cedb888777dd885cae583/websockets-15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c8c5c8e1bac05ef3c23722e591ef4f688f528235e2480f157a9cfe0a19081375", size = 181485 },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/c91c47103f1cd941b576bbc452601e9e01f67d5c9be3e0a9abe726491ab5/websockets-15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:86bfb52a9cfbcc09aba2b71388b0a20ea5c52b6517c0b2e316222435a8cdab72", size = 181466 },
+    { url = "https://files.pythonhosted.org/packages/16/32/a4ca6e3d56c24aac46b0cf5c03b841379f6409d07fc2044b244f90f54105/websockets-15.0-cp313-cp313-win32.whl", hash = "sha256:26ba70fed190708551c19a360f9d7eca8e8c0f615d19a574292b7229e0ae324c", size = 175673 },
+    { url = "https://files.pythonhosted.org/packages/c0/31/25a417a23e985b61ffa5544f9facfe4a118cb64d664c886f1244a8baeca5/websockets-15.0-cp313-cp313-win_amd64.whl", hash = "sha256:ae721bcc8e69846af00b7a77a220614d9b2ec57d25017a6bbde3a99473e41ce8", size = 176115 },
+    { url = "https://files.pythonhosted.org/packages/e8/b2/31eec524b53f01cd8343f10a8e429730c52c1849941d1f530f8253b6d934/websockets-15.0-py3-none-any.whl", hash = "sha256:51ffd53c53c4442415b613497a34ba0aa7b99ac07f1e4a62db5dcd640ae6c3c3", size = 169023 },
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add example dataflows for Bluesky offsite mentions and update dev dependencies.
> 
>   - **Examples**:
>     - Add `sink.py` for processing Bluesky offsite mentions and sending them to S2 sink.
>     - Add `source.py` for sourcing Bluesky offsite mentions and displaying them in a terminal bar chart.
>   - **Dependencies**:
>     - Add `plotext`, `rich`, and `websockets` to `dev` dependencies in `pyproject.toml` and `uv.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fbytewax-s2&utm_source=github&utm_medium=referral)<sup> for 3466df47472629eeca500ca129fa1b9bd958999c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->