### PR TITLE
refactor: avoid dual lookup in `part_fn()` 

### DIFF
--- a/src/bytewax_s2/_io.py
+++ b/src/bytewax_s2/_io.py
@@ -223,12 +223,12 @@ class S2Sink(FixedPartitionedSink):
     def part_fn(self, item_key: str) -> int:
         match self._partition_fn:
             case S2SinkPartitionFn.DIRECT:
-                if item_key in self._partitions:
-                    return self._partition_idx_map[item_key]
-                else:
+                idx = self._partition_idx_map.get(item_key)
+                if idx is None:
                     raise RuntimeError(
                         f"item with key: {item_key} doesn't match any of the existing partitions: {self._partitions}"
                     )
+                return idx
             case S2SinkPartitionFn.HASHED:
                 return super().part_fn(item_key)
             case _:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `part_fn()` in `_io.py` to use `dict.get()` for single lookup in `DIRECT` case, improving efficiency.
> 
>   - **Refactor**:
>     - In `part_fn()` in `_io.py`, replace dual lookup with `dict.get()` for `S2SinkPartitionFn.DIRECT` case to improve efficiency.
>     - Raises `RuntimeError` if `item_key` is not found in `_partition_idx_map`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fbytewax-s2&utm_source=github&utm_medium=referral)<sup> for 21d89fde6764718f57835605ef2696c3d6538698. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->