### PR TITLE
tests: fix mypy errors and style inconsistency

### DIFF
--- a/tests/sink.py
+++ b/tests/sink.py
@@ -1,23 +1,33 @@
 import os
-import bytewax.operators as op
-from bytewax.testing import TestingSource, run_main
-from bytewax.dataflow import Dataflow
-from bytewax_s2 import S2Config, S2SinkRecord, S2Sink
 
-AUTH_TOKEN = os.getenv("S2_AUTH_TOKEN")
-BASIN = os.getenv("S2_BASIN")
-STREAM_PREFIX = os.getenv("S2_STREAM_PREFIX")
+import bytewax.operators as op
+from bytewax.dataflow import Dataflow
+from bytewax.testing import TestingSource, run_main
+
+from bytewax_s2 import S2Config, S2Sink, S2SinkRecord
+
+AUTH_TOKEN = os.environ["S2_AUTH_TOKEN"]
+BASIN = os.environ["S2_BASIN"]
+STREAM_PREFIX = os.environ["S2_STREAM_PREFIX"]
 
 eof = 0
 
-flow = Dataflow("s2-sink-test")
-ints = op.input("input", flow, TestingSource([1, 2, 3, 4, 5, TestingSource.EOF]))
+
+def key(i: object) -> tuple[str, S2SinkRecord]:
+    if isinstance(i, int):
+        return (str(i % 2), S2SinkRecord(body=i.to_bytes(32)))
+    elif isinstance(i, TestingSource.EOF):
+        return (str(eof % 2), S2SinkRecord(body=eof.to_bytes(32)))
+    else:
+        raise RuntimeError(f"Unexpected type: {type(i)} for input: {i}")
+
+
+flow = Dataflow("s2_sink_test")
+ints = op.input("input", flow, TestingSource([1, 2, 3, 4, 5, TestingSource.EOF()]))
 keyed_ints = op.map(
-    "keying",
+    "key",
     ints,
-    lambda i: (str(i % 2), S2SinkRecord(body=i.to_bytes(32)))
-    if i != TestingSource.EOF
-    else (str(eof % 2), S2SinkRecord(body=eof.to_bytes(32))),
+    key,
 )
 op.output(
     "output",

--- a/tests/source.py
+++ b/tests/source.py
@@ -1,16 +1,18 @@
 import os
+
 import bytewax.operators as op
-from bytewax.testing import TestingSink, run_main
 from bytewax.dataflow import Dataflow
+from bytewax.testing import TestingSink, run_main
+
 from bytewax_s2 import S2Config, S2Source
 
-AUTH_TOKEN = os.getenv("S2_AUTH_TOKEN")
-BASIN = os.getenv("S2_BASIN")
-STREAM_PREFIX = os.getenv("S2_STREAM_PREFIX")
+AUTH_TOKEN = os.environ["S2_AUTH_TOKEN"]
+BASIN = os.environ["S2_BASIN"]
+STREAM_PREFIX = os.environ["S2_STREAM_PREFIX"]
 
-sink = []
+sink: list[int] = []
 
-flow = Dataflow("s2-source-test")
+flow = Dataflow("s2_source_test")
 int_bytes = op.input(
     "input",
     flow,
@@ -21,7 +23,7 @@ int_bytes = op.input(
         tail=False,
     ),
 )
-ints = op.map("parse-ints", int_bytes, lambda sr: int.from_bytes(sr.body))
+ints = op.map("parse_ints", int_bytes, lambda sr: int.from_bytes(sr.body))
 op.output("output", ints, TestingSink(sink))
 
 run_main(flow)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix mypy errors and style inconsistencies in `tests/sink.py` and `tests/source.py` by updating environment variable access, renaming functions, and adding type annotations.
> 
>   - **Environment Variables**:
>     - Replace `os.getenv` with `os.environ` in `tests/sink.py` and `tests/source.py` for `S2_AUTH_TOKEN`, `S2_BASIN`, and `S2_STREAM_PREFIX`.
>   - **Function and Variable Renames**:
>     - Rename `keying` to `key` in `tests/sink.py`.
>     - Rename `parse-ints` to `parse_ints` in `tests/source.py`.
>     - Rename `s2-sink-test` to `s2_sink_test` in `tests/sink.py`.
>     - Rename `s2-source-test` to `s2_source_test` in `tests/source.py`.
>   - **Type Annotations**:
>     - Add type annotation `list[int]` to `sink` in `tests/source.py`.
>   - **Miscellaneous**:
>     - Add `key()` function in `tests/sink.py` to handle keying logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fbytewax-s2&utm_source=github&utm_medium=referral)<sup> for d8b70d8633e853138966a1033bc88792a1544509. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->