### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release bytewax-s2 package
+on:
+  push:
+    tags: ["[0-9]+.[0-9]+.[0-9]+*"]
+  workflow_dispatch:
+jobs:
+  pypi_package_release:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # For PyPI trusted publishing
+      id-token: write
+      # For creating github release
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Read release version
+        id: read_version
+        uses: SebRollen/toml-action@v1.2.0
+        with:
+          file: pyproject.toml
+          field: project.version
+      - name: Verify tag and project version
+        if: ${{ steps.read_version.outputs.value != github.ref_name }}
+        run: |
+          echo "::error ::Tag doesn't match project version"
+          exit 1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.20"
+      - name: Build package
+        run: uv build
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Read changelog
+        id: read_changelog
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ steps.read_version.outputs.value }}
+      - name: Create github release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.read_version.outputs.value }}
+          body: ${{ steps.read_changelog.outputs.changes }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add GitHub Actions workflow `release.yml` to automate `bytewax-s2` package release, including version verification, building, publishing to PyPI, and creating a GitHub release.
> 
>   - **Workflow Addition**:
>     - Adds `release.yml` to `.github/workflows` for automating `bytewax-s2` package release.
>     - Triggers on tag pushes matching `[0-9]+.[0-9]+.[0-9]+*` and manual dispatch.
>   - **Release Process**:
>     - Checks out repository and reads version from `pyproject.toml`.
>     - Verifies tag matches project version; errors if not.
>     - Installs `uv` version `0.5.20` and builds package.
>     - Publishes package to PyPI using `pypa/gh-action-pypi-publish@release/v1`.
>     - Reads changelog and creates GitHub release with version and changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fbytewax-s2&utm_source=github&utm_medium=referral)<sup> for d326e1b5b581e03bfba7958eb7e2b4e26671291b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->